### PR TITLE
Correct typo in line 33

### DIFF
--- a/people/dwc/agent_actions_v2020-05-18.xml
+++ b/people/dwc/agent_actions_v2020-05-18.xml
@@ -30,7 +30,7 @@
         qualName="https://tdwg.github.io/attribution/people/dwc/terms/agentIdentifierType"
         dc:description="The type of identifier for the agent. Recommended best practice is to use a controlled vocabulary."
         examples='"ORCID", "ISNI", "Wikidata", "VIAF", "RoR", "Ringgold", "GRID"'
-        type:"string"
+        type="string"
         required="true"/>
     <property
         name="identifier"


### PR DESCRIPTION
When trying to install the Agent Actions extension in my IPT, I get the following error:

> An error occurred while trying to install extension https://tdwg.github.io/attribution/people/dwc/agent_actions_v2020-05-18.xml.
Can't parse local extension file: Attribute name "type:" associated with an element type "property" must be followed by the ' = ' character.

I think changing `type: "string"` in line 33 to `type="string"` will fix it.